### PR TITLE
ウィンドウのタイトルを動的に変更するようにした

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,6 @@ import { HomePage } from "./HomePage";
 import { OpenerPage } from "./OpenerPage";
 import { APP_BASE_PATH } from "./constants";
 
-// TODO windowタイトルも動的に変更したい
 // TODO serviceworkerでキャッシュさせてオフラインでも使えるようにしたい
 // TODO ファビコン作成
 // TODO コードの可読性向上

--- a/src/HomePage.tsx
+++ b/src/HomePage.tsx
@@ -2,8 +2,11 @@ import { useRef, useState } from "react";
 import queryString from "query-string";
 import "./HomePage.scss";
 import { APP_BASE_PATH } from "./constants";
+import { useDocumentTitle } from "./useDocumentTitle";
 
 export function HomePage() {
+  useDocumentTitle("ひらくだけ");
+  
   const [url, setUrl] = useState<string>("");
   const [title, setTitle] = useState<string>("");
 

--- a/src/OpenerPage.tsx
+++ b/src/OpenerPage.tsx
@@ -3,9 +3,12 @@ import * as QRCode from "qrcode";
 import "./OpenerPage.scss";
 import { useEffect, useRef } from "react";
 import { APP_BASE_PATH } from "./constants";
+import { useDocumentTitle } from "./useDocumentTitle";
 
 export function OpenerPage() {
   const { url, title } = useQueryParameters();
+  useDocumentTitle(`${title}を開く`);
+
   const qrCanvasRef = useRef<HTMLCanvasElement>(null);
 
   useEffect(() => {

--- a/src/useDocumentTitle.ts
+++ b/src/useDocumentTitle.ts
@@ -1,0 +1,7 @@
+import { useEffect } from "react";
+
+export function useDocumentTitle(title: string): void {
+  useEffect(() => {
+    document.title = title;
+  }, [title]);
+}


### PR DESCRIPTION
ホームページ: ひらくだけ
Opnerページ: 入力されたタイトル

{入力されたタイトル}+ひらくだけ　とかにしても良かったけど、ホームアイコンに使われるデフォルトのタイトルなので面倒がないように入力されたタイトルだけにした。

素のhtmlは「ひらくだけ」にしてある。