### PR TITLE
開いたあとにwindowを閉じるようにした

### DIFF
--- a/src/OpenerPage.tsx
+++ b/src/OpenerPage.tsx
@@ -19,6 +19,7 @@ export function OpenerPage() {
 
   const open = () => {
     window.open(url, "noreferrer");
+    window.close();
   };
 
   return (


### PR DESCRIPTION
Androidではちゃんと閉じる。
PCでは閉じない。
iOSは知らない。